### PR TITLE
Correct typo in bitwise AND operands

### DIFF
--- a/random/include/boost/random/threefry4x64.hpp
+++ b/random/include/boost/random/threefry4x64.hpp
@@ -66,7 +66,7 @@ namespace detail {
         inline static UIntType zth(const boost::uint_least64_t (&_output)[4])
             { return _output[0] & 0xFFFF; }
         inline static UIntType nth(const boost::uint_least64_t (&_output)[4], std::size_t n)
-            { return (_output[n>>2] >> ((n&11)<<4)) & 0xFFFF; }
+            { return (_output[n>>2] >> ((n&3)<<4)) & 0xFFFF; }
         inline static UIntType w_max()
             { return 0xFFFF; }
     };
@@ -75,7 +75,7 @@ namespace detail {
         inline static UIntType zth(const boost::uint_least64_t (&_output)[4])
             { return _output[0] & 0xFF; }
         inline static UIntType nth(const boost::uint_least64_t (&_output)[4], std::size_t n)
-            { return (_output[n>>3] >> ((n&111)<<3)) & 0xFF; }
+            { return (_output[n>>3] >> ((n&7)<<3)) & 0xFF; }
         inline static UIntType w_max()
             { return 0xFF; }
     };


### PR DESCRIPTION
Hi, thanks for providing this implementation of threefry4x64.

I think I may have noticed typos in the implementation of `extract4x64_impl::nth`. The original code has expressions like these:

`return (_output[n>>3] >> ((n&111)<<3)) & 0xFF; }`

I believe the `n&111` is a typo. The intention seems to be a bitwise AND with three set bits. But this is integer `111`, not `0b111`. In practice, this can produce a right shift that is too large for the type of `n`  and generate undefined behavior. I noticed this when comparing the behavior of programs produced by different compilers.

Correcting this to `n&7` seems to produce the correct results.

Are these expressions typos?